### PR TITLE
Batch Job name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+  
+## [0.6.0] - 2020-02-03
+### Changed
+- Batch name is now optional with .submit()
+
+### Fixed
+- Fixed #15: added name attribute to Batch

--- a/livy_submit/cli.py
+++ b/livy_submit/cli.py
@@ -257,8 +257,8 @@ def _livy_info_parser(subparsers) -> ArgumentParser:
 def _livy_submit_func(
     livy_url: str,
     namenode_url: str,
-    name: str,
     file: str,
+    name: str = None,
     driverMemory: str = None,
     driverCores: int = None,
     executorMemory: str = None,
@@ -403,7 +403,7 @@ def _livy_submit_parser(subparsers):
     ap.add_argument(
         "--name",
         action="store",
-        required=True,
+        required=False,
         help="The name that your Spark job should have on the Yarn RM",
     )
     ap.add_argument(

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -197,6 +197,19 @@ class LivyAPI:
                 continue
             data[var] = val
         #         print(data)
+
+        # check for collision with existing batch name
+        _, _, batches = self.all_info()
+        if batches:
+            for num,batch in batches.items():
+                if batch.name == name:
+                    msg = f'''The batch name '{name}' is already in use by Livy Batch Job {batch.id}.
+You can either
+  * change the name of this batch job,
+  * kill Batch Job {batch.id} with .kill({batch.id}),
+  * or wait for {batch.id} to finish and be removed from the output of .all_info()'''
+                    raise ValueError(msg)
+
         # Submit the data dict to the Livy Batches API to create a batch job
         response = self._request("post", self._base_url, data=data)
         return Batch(**response)

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -153,9 +153,9 @@ class LivyAPI:
             e.g.: file='hdfs://user/testuser/pi.py'
         name : str, optional
             The name that your Spark job should have on the Yarn RM. The supplied
-            name must be unique for all jobs currently returned by all_info() or
-            a ValueError is thrown. If the name is not provided will be will be listed
-            as None in Livy and as the the filename in the Yarn Resource Manager.
+            name must be unique for all known Livy jobs (starting, running, or completed) or
+            a ValueError is thrown. If the name is not provided the job name will
+            be listed as None in Livy and as the filename in the Yarn RM.
         driverMemory : str, optional
             e.g. 512m, 2g
             Amount of memory to use for the driver process, i.e. where

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -24,7 +24,8 @@ class Batch:
         )
 
     def __repr__(self):
-        return f"Batch(id={self.id}, name='{self.name}', appId='{self.appId}', appInfo={self.appInfo}, log='', state='{self.state}')"
+        _name = f"'{self.name}'" if self.name is not None else self.name
+        return f"Batch(id={self.id}, name={_name}, appId='{self.appId}', appInfo={self.appInfo}, log='', state='{self.state}')"
 
 
 class LivyAPI:
@@ -138,14 +139,17 @@ class LivyAPI:
 
         Parameters
         ----------
-        name : str
-            The name that your Spark job should have on the Yarn RM
         file : str
             The file that should be executed during your Spark job. This file
             path must be accessible from the nodes that run your Spark driver/executors.
             It is likely that this means that you will need to have pre-uploaded your file
             to hdfs and then use the hdfs path for this `file` variable.
             e.g.: file='hdfs://user/testuser/pi.py'
+        name : str, optional
+            The name that your Spark job should have on the Yarn RM. The supplied
+            name must be unique for all jobs currently returned by all_info() or
+            a ValueError is thrown. If the name is not provided will be will be listed
+            as None in Livy and as the the filename in the Yarn Resource Manager.
         driverMemory : str, optional
             e.g. 512m, 2g
             Amount of memory to use for the driver process, i.e. where
@@ -202,7 +206,7 @@ class LivyAPI:
         if name is not None:
             _, _, batches = self.all_info()
             for num,batch in batches.items():
-                if batch.name == name:
+                if (batch.name is not None) and (batch.name == name):
                     msg = f'''The batch name '{name}' is already in use by Livy Batch Job {batch.id}.
 You can either
   * change the name of this batch job,

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -24,8 +24,14 @@ class Batch:
         )
 
     def __repr__(self):
-        _name = f"'{self.name}'" if self.name is not None else self.name
-        return f"Batch(id={self.id}, name={_name}, appId='{self.appId}', appInfo={self.appInfo}, log='', state='{self.state}')"
+        def _as_none(value):
+            if value is None:
+                return None
+            else:
+                # return a fully quoted string in the repr
+                return f"'{self.name}'"
+
+        return f"Batch(id={self.id}, name={_as_none(self.name)}, appId={_as_none(self.appId)}, appInfo={self.appInfo}, log='', state='{self.state}')"
 
 
 class LivyAPI:

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -5,12 +5,13 @@ from typing import List, Tuple
 
 
 class Batch:
-    def __init__(self, id: str, appId: str, appInfo: dict, log: List, state: str):
+    def __init__(self, id: str, name: str, appId: str, appInfo: dict, log: List, state: str):
         self.id = id
         self.appId = appId
         self.appInfo = appInfo
         self.log = log
         self.state = state
+        self.name = name
 
     def __eq__(self, other):
         """Make an equality comparison ignoring the logs"""
@@ -19,10 +20,11 @@ class Batch:
             and self.appId == other.appId
             and self.appInfo == other.appInfo
             and self.state == other.state
+            and self.name == other.name
         )
 
     def __repr__(self):
-        return f"Batch(id={self.id}, appId='{self.appId}', appInfo={self.appInfo}, log='', state='{self.state}')"
+        return f"Batch(id={self.id}, name='{self.name}', appId='{self.appId}', appInfo={self.appInfo}, log='', state='{self.state}')"
 
 
 class LivyAPI:
@@ -185,7 +187,7 @@ class LivyAPI:
              'appId': None,
              'appInfo': {'driverLogUrl': None, 'sparkUiUrl': None},
              'log': ['stdout: ', '\nstderr: ', '\nYARN Diagnostics: ']}
-             
+
         """
         # Get a dictionary of all of the non-None values that are passed in
         local_items = locals()

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -26,10 +26,10 @@ class Batch:
     def __repr__(self):
         def _as_none(value):
             if value is None:
-                return None
+                return value
             else:
                 # return a fully quoted string in the repr
-                return f"'{self.name}'"
+                return f"'{value}'"
 
         return f"Batch(id={self.id}, name={_as_none(self.name)}, appId={_as_none(self.appId)}, appInfo={self.appInfo}, log='', state='{self.state}')"
 

--- a/livy_submit/livy_api.py
+++ b/livy_submit/livy_api.py
@@ -120,8 +120,8 @@ class LivyAPI:
 
     def submit(
         self,
-        name: str,
         file: str,
+        name: str = None,
         driverMemory: str = None,
         driverCores: int = None,
         executorMemory: str = None,
@@ -199,8 +199,8 @@ class LivyAPI:
         #         print(data)
 
         # check for collision with existing batch name
-        _, _, batches = self.all_info()
-        if batches:
+        if name is not None:
+            _, _, batches = self.all_info()
             for num,batch in batches.items():
                 if batch.name == name:
                     msg = f'''The batch name '{name}' is already in use by Livy Batch Job {batch.id}.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -40,11 +40,13 @@ def base_cmd(livy_submit_config_file, sparkmagic_config_file):
     ]
     return " ".join(base_cmd)
 
+
 @pytest.fixture(scope='session')
 def info_cmd(base_cmd):
     return base_cmd + ' info'
 
-@pytest.fixture(scope="session")
+
+@pytest.fixture(scope="function")
 def job_submit_cmd(pi_file, livy_submit_config_file, base_cmd):
     submit_cmd = (
         base_cmd
@@ -53,7 +55,7 @@ def job_submit_cmd(pi_file, livy_submit_config_file, base_cmd):
             [
                 "submit",
                 "--name",
-                "test_cli_submit",
+        	"test-cli_submit-from-pytest-%s" % time.time(),
                 "--file",
                 pi_file,
                 "--args",
@@ -79,7 +81,7 @@ def submitted_job(kinit, pi_file, capsys, job_submit_cmd, info_cmd):
     
     tries = 0
     info_cmd = '%s %d' % (info_cmd, batch_job1.id)
-    while batch_job1.appId == 'None' and tries < 5:
+    while batch_job1.appId == 'None' and tries < 10:
         time.sleep(2)
         tries += 1
         with sysargv(info_cmd):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -68,6 +68,26 @@ def job_submit_cmd(pi_file, livy_submit_config_file, base_cmd):
 
 
 @pytest.fixture(scope="function")
+def job_submit_cmd_noname(pi_file, livy_submit_config_file, base_cmd):
+    submit_cmd = (
+        base_cmd
+        + " "
+        + " ".join(
+            [
+                "submit",
+                "--file",
+                pi_file,
+                "--args",
+                "'100'",
+            ]
+        )
+    )
+    print(submit_cmd)
+    return submit_cmd
+
+
+@pytest.mark.parametrize('job_submit_cmd', [job_submit_cmd, job_submit_cmd_noname])
+@pytest.fixture(scope="function")
 def submitted_job(kinit, pi_file, capsys, job_submit_cmd, info_cmd):
     with sysargv(job_submit_cmd):
         cli.cli()
@@ -81,7 +101,7 @@ def submitted_job(kinit, pi_file, capsys, job_submit_cmd, info_cmd):
     
     tries = 0
     info_cmd = '%s %d' % (info_cmd, batch_job1.id)
-    while batch_job1.appId == 'None' and tries < 10:
+    while batch_job1.appId is None and tries < 10:
         time.sleep(2)
         tries += 1
         with sysargv(info_cmd):

--- a/test/test_livy_api.py
+++ b/test/test_livy_api.py
@@ -87,6 +87,14 @@ def test_end_to_end(api_instance, kinit, upload_pi_file, livy_test_user_and_pass
     #print(logstring)
 
 
+def test_unique_job_name(api_instance, kinit, upload_pi_file, livy_test_user_and_password):
+    name="test-job-from-pytest-%s" % time.time()
+    job1 = api_instance.submit(name=name, file=upload_pi_file)
+
+    with pytest.raises(ValueError):
+        job2 = api_instance.submit(name=name, file=upload_pi_file)
+
+
 def test_all_info(api_instance, kinit):
     resp = api_instance.all_info()
 


### PR DESCRIPTION
This fixes #15 
* `Batch` now support `name` as an argument in `__init__`
* `submit()` will throw `ValueError` if the name of the submitted job matches one returned by `all_info()`
    * test added